### PR TITLE
Poker game logic improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,7 +206,12 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
+######################
 ## project specific ##
 
 # server 
 *host_key*
+
+# nohup log
+nohup.out
+######################

--- a/poker/ai.py
+++ b/poker/ai.py
@@ -19,7 +19,17 @@ class PokerAI:
         
         # game_state contains 'community', 'pot', 'bets', 'players'
         community = game_state.get('community', [])
+        bets = game_state.get('bets', {})
         chips = self.player.chips
+        
+        # Calculate how much we need to call
+        current_bet = max(bets.values()) if bets else 0
+        my_bet = bets.get(self.player.name, 0)
+        call_amount = max(current_bet - my_bet, 0)
+        
+        # If we don't have enough money to call, fold
+        if call_amount > chips:
+            return {'action': 'fold', 'amount': 0}
 
         # Very naive rules
         if not community:

--- a/poker/game.py
+++ b/poker/game.py
@@ -202,10 +202,15 @@ class Game:
                 
             # Check if player has no chips
             if p.chips <= 0:
-                # Give player a small rebuy to continue playing
-                p.chips = 50  # Small rebuy amount
-                self.action_history.append(f"{p.name} received $50 rebuy (was broke)")
-                
+                if getattr(p, 'rebuys', 0) < 1:
+                    p.chips = 50  # Small rebuy amount
+                    p.rebuys += 1
+                    self.action_history.append(f"{p.name} received $50 rebuy (was broke, {p.rebuys}/1)")
+                else:
+                    p.state = 'eliminated'
+                    self.action_history.append(f"{p.name} eliminated (no rebuys left)")
+                    continue
+            
             # Calculate current bet fresh for each player's turn
             current_bet = max(self.bets.values()) if self.bets else 0
             

--- a/poker/game.py
+++ b/poker/game.py
@@ -214,7 +214,7 @@ class Game:
                     
                 # Check if player has no chips
                 if p.chips <= 0:
-                    if getattr(p, 'rebuys', 0) < 1:
+                    if p.rebuys < 1:
                         p.chips = 50  # Small rebuy amount
                         p.rebuys += 1
                         self.action_history.append(f"{p.name} received $50 rebuy (was broke, {p.rebuys}/1)")

--- a/poker/player.py
+++ b/poker/player.py
@@ -22,6 +22,7 @@ class Player:
         self.chips = chips
         self.hand: List[Any] = []
         self.state: str = 'active'  # active, folded, all-in, disconnected
+        self.rebuys: int = 0  # Track number of rebuys
         # actor(game_state) -> {'action': str, 'amount': int}
         # actor may be sync or async; typing is broad to accept both.
         self.actor: Optional[Callable[[dict], Any]] = None

--- a/poker/ssh_server.py
+++ b/poker/ssh_server.py
@@ -200,11 +200,25 @@ class _SimpleSessionBase:
                     pass
             return
 
-        # seat <name> registers player with the server_state
+        # seat [name] registers player with the server_state
         if cmd.lower().startswith("seat"):
             parts = cmd.split()
-            if len(parts) >= 2 and self._server_state is not None:
-                name = parts[1]
+            if self._server_state is not None:
+                if len(parts) >= 2:
+                    # seat <name> - use provided name
+                    name = parts[1]
+                elif len(parts) == 1 and self._username:
+                    # seat (no args) - use SSH username
+                    name = self._username
+                else:
+                    # No name provided and no SSH username available
+                    try:
+                        self._stdout.write("Usage: seat [name] (defaults to SSH username)\r\n\r\n❯ ")
+                        await self._stdout.drain()
+                    except Exception:
+                        pass
+                    return
+                
                 try:
                     player = self._server_state.register_player_for_session(name, self)
                     try:
@@ -220,7 +234,7 @@ class _SimpleSessionBase:
                         pass
             else:
                 try:
-                    self._stdout.write("Usage: seat <name>\r\n\r\n❯ ")
+                    self._stdout.write("Server state not available\r\n\r\n❯ ")
                     await self._stdout.drain()
                 except Exception:
                     pass


### PR DESCRIPTION
This pull request introduces several improvements to the poker game logic and SSH server interface, focusing on making the betting rounds more accurate to real poker rules, improving player rebuy handling, and enhancing the SSH user experience. The most significant changes are grouped below by theme.

**Poker Game Logic Improvements:**

* Refactored `betting_round` in `poker/game.py` to implement a proper betting loop: the round now continues until all active players have called or folded, and players are prompted to act again after a raise. This replaces the previous single-pass approach. [[1]](diffhunk://#diff-2d5792972acb5e412a27185c73e234fabc3b6fb71267ea676e5134e240fc699eL191-R259) [[2]](diffhunk://#diff-2d5792972acb5e412a27185c73e234fabc3b6fb71267ea676e5134e240fc699eR275-R316) [[3]](diffhunk://#diff-2d5792972acb5e412a27185c73e234fabc3b6fb71267ea676e5134e240fc699eL309-R342)
* Improved handling of player rebuys and elimination: players now have a tracked number of rebuys (`rebuys`), and are eliminated if they run out of chips and rebuys. [[1]](diffhunk://#diff-970cef7cdf4f4977d86460dff8f9ebbbe34942ea6876ca5043b51c837f121bc7R25) [[2]](diffhunk://#diff-2d5792972acb5e412a27185c73e234fabc3b6fb71267ea676e5134e240fc699eL191-R259)
* Updated betting and action validation: players attempting to check when a bet is outstanding are now forced to fold, and invalid bet amounts are treated as calls or checks as appropriate.
* The AI now folds if it cannot afford to call the current bet, preventing negative chip balances.

**SSH Server and User Experience Enhancements:**

* Added SSH username awareness: sessions now track and display the SSH username, and the `whoami` command reports the connected user. [[1]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cL23-R23) [[2]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cR32-R39) [[3]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cL169-R174)
* Improved the `seat` command: users can now seat themselves using their SSH username by running `seat` with no arguments, and the server provides clearer usage feedback.
* Implemented auto-seating: if a user starts a game without seating themselves, the server automatically seats them using their SSH username.
* Added global tracking of the current SSH username for session creation, ensuring the correct username is used throughout the session lifecycle. [[1]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cR286-R294) [[2]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cR313-R318)

These changes together make the poker game more realistic and robust, and provide a smoother, more user-friendly SSH interface.