### PR TITLE
Allow port reuse

### DIFF
--- a/poker/ssh_server.py
+++ b/poker/ssh_server.py
@@ -629,6 +629,7 @@ class SSHServer:
             self.port,
             server_host_keys=[str(host_key_path)],
             session_factory=session_factory,
+            reuse_address=True,
         )
 
         logging.info(f"SSH server listening on {self.host}:{self.port}")


### PR DESCRIPTION
This pull request makes a small update to the SSH server setup by enabling address reuse. This change allows the server to restart and bind to the same port more reliably, which can be helpful during development or when recovering from crashes.

* Added the `reuse_address=True` parameter to the SSH server initialization in `poker/ssh_server.py` to allow the server to reuse the same address without waiting for the OS to release it.