### PR TITLE
SSH auth & AI chip management

### DIFF
--- a/poker/database.py
+++ b/poker/database.py
@@ -304,16 +304,18 @@ class DatabaseManager:
     def update_game_stats(self, player_name: str, winnings_change: int = 0) -> None:
         """Update player's game statistics."""
         with self.get_cursor() as cursor:
-            # Update games played count
+            # Update games played count and stats
+            winnings_to_add = max(0, winnings_change)  # Only positive changes
+            losses_to_add = abs(min(0, winnings_change))  # Only negative changes, made positive
+            
             cursor.execute("""
                 UPDATE wallets 
                 SET games_played = games_played + 1,
-                    total_winnings = total_winnings + CASE WHEN ? > 0 THEN ? ELSE 0 END,
-                    total_losses = total_losses + CASE WHEN ? < 0 THEN ABS(?) ELSE 0 END,
+                    total_winnings = total_winnings + ?,
+                    total_losses = total_losses + ?,
                     last_activity = ?
                 WHERE player_name = ?
-            """, (winnings_change, winnings_change, winnings_change, winnings_change, 
-                  time.time(), player_name))
+            """, (winnings_to_add, losses_to_add, time.time(), player_name))
     
     def get_leaderboard(self, limit: int = 10) -> List[Dict[str, Any]]:
         """Get top players by total winnings."""

--- a/poker/player.py
+++ b/poker/player.py
@@ -137,6 +137,13 @@ class PlayerManager:
                     # The wallet balance IS the chips - no transfer needed
                     wallet_manager._update_cache(player.name, balance=player.chips)
                     
+                    # Auto-save wallet to database after each game
+                    success = wallet_manager.save_wallet_to_database(player.name)
+                    if success:
+                        logging.info(f"Auto-saved wallet for {player.name} after round completion")
+                    else:
+                        logging.error(f"Failed to auto-save wallet for {player.name} after round completion")
+                    
                     # Log final result with round winnings
                     round_winnings = player.get_winnings()
                     db.log_action(

--- a/poker/player.py
+++ b/poker/player.py
@@ -138,7 +138,9 @@ class PlayerManager:
                     wallet_manager._update_cache(player.name, balance=player.chips)
                     
                     # Auto-save wallet to database after each game
-                    success = wallet_manager.save_wallet_to_database(player.name)
+                    success = wallet_manager.save_wallet_to_database(
+                        player.name, 'GAME_RESULT', 'Auto-save after game'
+                    )
                     if success:
                         logging.info(f"Auto-saved wallet for {player.name} after round completion")
                     else:

--- a/poker/wallet.py
+++ b/poker/wallet.py
@@ -67,7 +67,8 @@ class WalletManager:
         # Update last activity
         self._wallet_cache[player_name]['last_activity'] = time.time()
     
-    def save_wallet_to_database(self, player_name: str) -> bool:
+    def save_wallet_to_database(self, player_name: str, transaction_type: str = 'MANUAL_SAVE', 
+                               description_prefix: str = 'Manual save') -> bool:
         """Manually save a wallet from cache to database."""
         if player_name not in self._wallet_cache:
             logging.debug(f"No cached wallet found for {player_name}, nothing to save")
@@ -98,8 +99,8 @@ class WalletManager:
             
             # Update database with cached values
             self.db.update_wallet_balance(
-                player_name, new_balance, 'MANUAL_SAVE',
-                f"Manual save: ${old_balance} -> ${new_balance}"
+                player_name, new_balance, transaction_type,
+                f"{description_prefix}: ${old_balance} -> ${new_balance}"
             )
             
             # Update game stats with the actual balance change (not session total)


### PR DESCRIPTION
This pull request introduces improvements to both the AI player chip management logic and the SSH authentication instructions. The most significant change is the addition of a top-up mechanism for AI players with low chip balances, allowing them to continue playing instead of being removed or left inactive. Additionally, the SSH authentication instructions have been updated throughout the codebase to provide clearer guidance on generating SSH keypairs, making it easier for users to connect successfully.

### AI Player Management Improvements

* Added logic to automatically top-up AI players whose chip balance falls below $25, resetting their chips and incrementing their rebuy count so they can keep playing. This includes logging the top-up action for auditing and debugging. (`poker/player.py`)
* Clarified the comments and logic for handling AI players who go broke, distinguishing between full respawn for zero chips and top-up for low balance. (`poker/player.py`)

### SSH Authentication Instructions Update

* Updated all SSH authentication banners and instructions to recommend a simpler `ssh-keygen` command: `ssh-keygen -N "" -t ed25519` (with instructions to press ENTER at all prompts), replacing the previous more complex command. This change appears in several locations to ensure consistency and clarity for users. (`poker/ssh_server.py`) [[1]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cL1991-R1998) [[2]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cL2016-R2024) [[3]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cL2159-R2165)