### PR TITLE
`systemd` user service unit

### DIFF
--- a/poker-over-ssh.service
+++ b/poker-over-ssh.service
@@ -1,0 +1,20 @@
+# You may want to change the user service file to match your username and paths
+# Save this file as ~/.config/systemd/user/poker-over-ssh.service
+#
+# Then enable and start the service with:
+# systemctl --user enable --now poker-over-ssh.service
+
+[Unit]
+Description=Poker over SSH (user service)
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/qincai/Poker-over-SSH
+ExecStart=/home/qincai/Poker-over-SSH/.venv/bin/python /home/qincai/Poker-over-SSH/main.py --port 23456
+Restart=on-failure
+RestartSec=10
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=default.target

--- a/poker/ssh_server.py
+++ b/poker/ssh_server.py
@@ -1618,7 +1618,7 @@ class RoomSession:
                         
                         added_ais += 1
                         
-                # Ensure we have at least N AI players in the room (user requested at least 3 AIs)
+                # Ensure we have at least N AI players in the room
                 required_ai_count = 3
                 try:
                     current_ai_count = len([p for p in room.pm.players if p.is_ai])

--- a/poker/ssh_server.py
+++ b/poker/ssh_server.py
@@ -1630,7 +1630,7 @@ class RoomSession:
                     existing_ai_names = {p.name for p in room.pm.players if p.is_ai}
 
                     for ai_name in ai_names:
-                        # Stop when we've reached the required AI count
+                        # Stop when reached the required AI count
                         current_ai_count = len([p for p in room.pm.players if p.is_ai])
                         if current_ai_count >= required_ai_count:
                             break

--- a/poker/ssh_server.py
+++ b/poker/ssh_server.py
@@ -837,7 +837,7 @@ class RoomSession:
                     
             elif subcmd == "saveall":
                 # Admin command to save all cached wallets
-                if self._username in ['admin', 'root']:  # Basic admin check
+                if self._username in ['root']:  # Basic admin check
                     saved_count = wallet_manager.save_all_wallets()
                     self._stdout.write(f"✅ Saved {saved_count} wallets to database\r\n\r\n❯ ")
                 else:
@@ -845,7 +845,7 @@ class RoomSession:
                     
             elif subcmd == "check":
                 # Admin command to check database integrity
-                if self._username in ['admin', 'root']:  # Basic admin check
+                if self._username in ['root']:  # Basic admin check
                     from poker.database import get_database
                     db = get_database()
                     issues = db.check_database_integrity()
@@ -864,7 +864,7 @@ class RoomSession:
                     
             elif subcmd == "audit":
                 # Admin command to audit specific player's transactions
-                if self._username in ['admin', 'root']:  # Basic admin check
+                if self._username in ['root']:  # Basic admin check
                     if len(parts) < 3:
                         self._stdout.write(f"❌ Usage: wallet audit <player_name>\r\n\r\n❯ ")
                     else:
@@ -1638,19 +1638,13 @@ class RoomSession:
                         if ai_name in existing_ai_names:
                             continue  # AI already exists
 
-                        # Check respawn cooldown and respawn if allowed
+                        # Force-add AI player to meet the minimum AI count (IGNORE respawn cooldown here)
                         try:
-                            from poker.database import get_database
-                            db = get_database()
-                            if not db.can_ai_respawn(ai_name):
-                                logging.debug(f"AI {ai_name} still on respawn cooldown, skipping")
-                                continue
-                            db.respawn_ai(ai_name)
+                            logging.debug(f"Adding AI player (to reach AI minimum): {ai_name}")
+                            ai_player = room.pm.register_player(ai_name, is_ai=True, chips=200)
                         except Exception as e:
-                            logging.error(f"Error checking/respawning AI {ai_name}: {e}")
-
-                        logging.debug(f"Adding AI player (to reach AI minimum): {ai_name}")
-                        ai_player = room.pm.register_player(ai_name, is_ai=True, chips=200)
+                            logging.error(f"Failed to add AI {ai_name}: {e}")
+                            continue
 
                         # Set up AI actor
                         from poker.ai import PokerAI


### PR DESCRIPTION
This pull request introduces a new systemd user service file for running Poker over SSH and updates the AI player management logic and admin command permissions in `poker/ssh_server.py`. The most notable changes are the addition of the service file for easier deployment, stricter admin checks for wallet commands, and enhanced logic to ensure a minimum number of AI players in a game room.

**Deployment & Service Management:**
* Added a new systemd user service file `poker-over-ssh.service` with instructions, making it easier to run Poker over SSH as a user service.

**Admin Command Permissions:**
* Restricted admin wallet commands (`saveall`, `check`, `audit`) to only the `root` user, removing `admin` from the allowed list for stricter privilege enforcement in `poker/ssh_server.py`. [[1]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cL840-R848) [[2]](diffhunk://#diff-d505f5a91866b741ca0b1ac7c23120c1c928f5b8fe3d5e63e9a03b3e3248148cL867-R867)

**AI Player Management:**
* Declared a list of potential AI player names (`ai_names`) for use in both player addition loops in `async def _handle_start(self)`.
* Implemented logic to ensure at least three AI players are present in a room, force-adding AI players if necessary and bypassing respawn cooldowns for this requirement.